### PR TITLE
changing kiva-ml service schema to support client session id

### DIFF
--- a/conf/snowplow_ml_service_event_schema_1_0_0.json
+++ b/conf/snowplow_ml_service_event_schema_1_0_0.json
@@ -10,6 +10,10 @@
 
 	"type": "object",
 	"properties": {
+		"sessionId": {
+			"type": ["string", "null"],
+			"description": "session id assigned in the client and passed to service"
+		},
 		"category": {
 			"type": "string",
 			"description": "user interaction type of response given by service"
@@ -36,7 +40,6 @@
 		},
 		"timestamp": {
 			"type": "string",
-			"format": "date-time",
 			"description": "date and time the request was received"
 		}
 	},


### PR DESCRIPTION
The clients are now passing session id to federation, this change will allow the kiva-ml service to record the session id along with the analytics for the requests.