### PR TITLE
MOB-921 Add user pref schema for global context

### DIFF
--- a/conf/snowplow_user_pref_global_schema_1_0_0.json
+++ b/conf/snowplow_user_pref_global_schema_1_0_0.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "User preferences applied in a global context",
+	"self": {
+		"vendor": "org.kiva",
+		"name": "user_pref_global",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"theme": {
+			"type": "string",
+			"enum": ["dark", "light"],
+			"description": "UI theme setting (night mode)"
+		}
+	},
+	"additionalProperties": false
+}


### PR DESCRIPTION
_Opening a draft for discussion. I'm not sure of the best name for this, or how it might fit into future schema changes._

This introduces a schema to capture a user's theme preference (light vs dark/night mode). The `theme` property will be applied to a [global context](https://snowplowanalytics.com/blog/2019/07/03/snowplow-android-tracker-1.2.0-released-with-global-contexts/), attached to all events sent by the mobile app ([MOB-921](https://kiva.atlassian.net/browse/MOB-921)).

We only have a need to track `theme` today, but would like to allow (in the naming of this schema) for future additions to track other preferences of the client app or device. I could imagine one day tracking custom font sizing, for example.

I didn't target mobile apps specifically, assuming it's possible we'd want to track similar preferences on web which don't fit into the predefined protocol.