### PR TITLE
UMP-69 | added reference json file

### DIFF
--- a/conf/snowplow_allowed_structured_event_values.json
+++ b/conf/snowplow_allowed_structured_event_values.json
@@ -1,0 +1,1 @@
+{"actions": ["click", "fail", "succeed", "submit", "toggle", "enable", "disable", "show", "dismiss", "update", "filter", "add-to-basket"], "categories": ["app", "basket", "borrow", "borrower-profile", "event-tracking", "notification", "portfolio", "search", "subscription", "authentication", "loan-card", "donation", "payment", "faq"]}


### PR DESCRIPTION
# Jira Ticket
https://kiva.atlassian.net/browse/UMP-69

# What is this doing?
Adds a json file with the allowed structured event `category` and `action` values defined in the [Web Event Examples doc](https://docs.google.com/spreadsheets/d/1pbxxYDfeOkrGhFi8HWl5K-vCPXaqO3bXS1Io3E_SDKc/edit?usp=sharing). 
