### PR TITLE
feat: add checkout upsell recommendation event schema

### DIFF
--- a/conf/snowplow_checkout_upsell_recommendation_event_schema_1_0_0.json
+++ b/conf/snowplow_checkout_upsell_recommendation_event_schema_1_0_0.json
@@ -1,0 +1,38 @@
+{
+	"$schema": "https://raw.githubusercontent.com/kiva/snowplow/master/conf/snowplow_checkout_upsell_recommendation_event_schema_1_0_0.json#",
+	"description": "Schema for Kiva checkout upsell recommendation display events",
+	"self": {
+		"vendor": "org.kiva",
+		"name": "checkout_upsell_recommendation_event",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"balance": {
+			"type": ["number", "null"]
+		},
+		"basketTotal": {
+			"type": "number"
+		},
+		"modelVersion": {
+			"type": "string"
+		},
+		"recommendedRanges": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"start": {
+						"type": "number"
+					},
+					"end": {
+						"type": "number"
+					}
+				}
+			}
+		}
+	},
+	"additionalProperties": false
+}


### PR DESCRIPTION
Adds the Snowplow self-describing event schema backing the MP-3004 checkout upsell (bandit) instrumentation.

Fired from kiva-ui `CheckoutPage.vue` when a model-recommended checkout upsell loan is shown. Payload:

- `balance` — account balance in dollars as passed to the recommendation API (`null` for logged-out)
- `basketTotal` — basket total in dollars as passed to the recommendation API (`null` if not sent)
- `modelVersion` — model version returned by the recommendation API
- `recommendedRanges` — full ordered list of `{ start, end }` amount-left ranges as returned

Follows the existing `conf/` schema conventions: vendor `org.kiva`, `jsonschema` 1-0-0, `additionalProperties: false`. `balance` and `basketTotal` are nullable.

Ticket: https://kiva.atlassian.net/browse/MP-3004
